### PR TITLE
Add failing test for 2d array with js inlining

### DIFF
--- a/src/test/java/org/thymeleaf/inline/ScriptInlineTest.java
+++ b/src/test/java/org/thymeleaf/inline/ScriptInlineTest.java
@@ -153,6 +153,21 @@ public class ScriptInlineTest {
 
 
 
+	@Test
+	public void test2dArray() throws Exception {
+
+		testInlineResult(
+				"   var array = [ [1, 2], [3, 4] ];",
+				"   var array = [ [1, 2], [3, 4] ];");
+
+		testInlineResult(
+				"   var array = [[1, 2], [3, 4]];",
+				"   var array = [[1, 2], [3, 4]];");
+
+	}
+
+
+
     @Test
     public void testCollectionInline() throws Exception {
 


### PR DESCRIPTION
Seems to be a regression that was fixed in 2.0 but failing on 3.0 now. See https://github.com/thymeleaf/thymeleaf/issues/22