### PR TITLE
Added inputStream method to ITemplateResources

### DIFF
--- a/src/test/java/org/thymeleaf/spring5/templateresolver/SpringResourceTemplateResolverSpring4Test.java
+++ b/src/test/java/org/thymeleaf/spring5/templateresolver/SpringResourceTemplateResolverSpring4Test.java
@@ -1,20 +1,20 @@
 /*
  * =============================================================================
- * 
+ *
  *   Copyright (c) 2011-2016, The THYMELEAF team (http://www.thymeleaf.org)
- * 
+ *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- * 
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
- * 
+ *
  * =============================================================================
  */
 package org.thymeleaf.spring5.templateresolver;
@@ -68,7 +68,15 @@ public final class SpringResourceTemplateResolverSpring4Test {
 
         Assert.assertEquals(expected, testResource);
 
+
+        final byte[] templateResourceBytes = IOUtils.toByteArray(templateResource.inputStream());
+
+        final byte[] expectedBytes =
+               IOUtils.toByteArray(
+                        ClassLoaderUtils.getClassLoader(SpringResourceTemplateResolverSpring4Test.class).getResourceAsStream(templateLocation));
+
+        Assert.assertArrayEquals(expectedBytes, templateResourceBytes);
     }
 
-    
+
 }


### PR DESCRIPTION
The main reason for adding this is our usecase of using thymeleaf for e-mail templates.

To refer to images and other binary resources, I created an extension tag processor that reads the resource, adds it to a special container in a context, and outputs a "cid:unique-code" url to refer to the image. However I need to be able to load the resource as binary data, and ITemplateResource only has a `reader` method. I added an `inputStream` method to ITemplateResource and all its implementations in the thymeleaf and thymeleaf-spring repositories. I added a unit test so that this method has the same amount of testing as the `reader` method. 

(Since the `reader` methods were all changes to use the `inputStream` method to avoid code duplication, the ability to load a resource at all also means that the `inputStream()` method worked, so it's implicitly tested in many more cases, just as the `reader` method is)

This pull request has accompanying pull requests in thymeleaf-spring and thymeleaf repositories.